### PR TITLE
Fix color set API and invariant role conversion

### DIFF
--- a/PlanningCenter.cs
+++ b/PlanningCenter.cs
@@ -6,7 +6,7 @@ namespace CreateSoundRoomSchedule;
 
 public sealed class TeamMember(string name, string role)
 {
-    public string Role => role.ToLower();
+public string Role => role.ToLowerInvariant();
     public string Name => name;
 }
 

--- a/Program.cs
+++ b/Program.cs
@@ -146,7 +146,7 @@ static void AddDaysOfWeekHeader(ExcelWorksheet ws, ref int row)
         cell.Style.VerticalAlignment = ExcelVerticalAlignment.Center;
         cell.Style.HorizontalAlignment = ExcelHorizontalAlignment.Center;
         cell.Style.Fill.PatternType = ExcelFillStyle.Solid;
-        cell.Style.Fill.SetBackground(i == 0 ? Color.LightBlue : Color.LightGray);
+        cell.Style.Fill.BackgroundColor.SetColor(i == 0 ? Color.LightBlue : Color.LightGray);
         cell.Style.Locked = true;
 
         cell.Value = daysOfWeek[i].ToString();
@@ -185,7 +185,7 @@ static void AddCalendar(ExcelWorksheet ws, DateOnly month, List<Holiday> holiday
         cell.Style.VerticalAlignment = ExcelVerticalAlignment.Top;
         cell.Style.HorizontalAlignment = ExcelHorizontalAlignment.Left;
         cell.Style.Fill.PatternType = ExcelFillStyle.Solid;
-        cell.Style.Fill.SetBackground(day.DayOfWeek switch {
+        cell.Style.Fill.BackgroundColor.SetColor(day.DayOfWeek switch {
                 DayOfWeek.Sunday => Color.LightYellow,
                 DayOfWeek.Wednesday => Color.LightCyan,
                 _ => Color.White


### PR DESCRIPTION
## Summary
- fix fill color API by using `BackgroundColor.SetColor`
- use invariant culture for role normalization

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a5be80ca88330ab0e585bc7960a8a