### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![.NET](https://github.com/markjulmar/CreateSoundRoomSchedule/actions/workflows/dotnet.yml/badge.svg)](https://github.com/markjulmar/CreateSoundRoomSchedule/actions/workflows/dotnet.yml)
 
 ## Overview
-The `CreateSoundRoomSchedule` project is a C# application to generate an Excel spreadsheet with the planned services for for a church. It interacts with the [Planning Center](https://www.planningcenter.com/) API to create a three-month calendar set for a given quarter. This .NET Core application reads data from Planning Center Online for all planned services in a specific quarter. It generates an Excel spreadsheet containing a 3-month calendar to identify the people assigned to manage A/V weekly. It also pulls public holidays and includes them in the calendar data.
+The `CreateSoundRoomSchedule` project is a C# application to generate an Excel spreadsheet with the planned services for a church. It interacts with the [Planning Center](https://www.planningcenter.com/) API to create a three-month calendar set for a given quarter. This .NET Core application reads data from Planning Center Online for all planned services in a specific quarter. It generates an Excel spreadsheet containing a 3-month calendar to identify the people assigned to manage A/V weekly. It also pulls public holidays and includes them in the calendar data.
 
 ![Sample calendar in Excel](./images/calendar-example.png)
 


### PR DESCRIPTION
## Summary
- fix double word in README overview

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a5dfafa108330a118a94cba9ee344