### PR TITLE
Add tests for quarter calculation

### DIFF
--- a/CreateSoundRoomSchedule.sln
+++ b/CreateSoundRoomSchedule.sln
@@ -2,15 +2,21 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CreateSoundRoomSchedule", "CreateSoundRoomSchedule.csproj", "{40B2AAB5-863F-492F-B46C-B25572E528F0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CreateSoundRoomSchedule.Tests", "tests/CreateSoundRoomSchedule.Tests/CreateSoundRoomSchedule.Tests.csproj", "{A1A0F8E8-FCB1-45A3-9397-02D933583BDF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{40B2AAB5-863F-492F-B46C-B25572E528F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{40B2AAB5-863F-492F-B46C-B25572E528F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{40B2AAB5-863F-492F-B46C-B25572E528F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{40B2AAB5-863F-492F-B46C-B25572E528F0}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {40B2AAB5-863F-492F-B46C-B25572E528F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {40B2AAB5-863F-492F-B46C-B25572E528F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {40B2AAB5-863F-492F-B46C-B25572E528F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {40B2AAB5-863F-492F-B46C-B25572E528F0}.Release|Any CPU.Build.0 = Release|Any CPU
+                {A1A0F8E8-FCB1-45A3-9397-02D933583BDF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {A1A0F8E8-FCB1-45A3-9397-02D933583BDF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {A1A0F8E8-FCB1-45A3-9397-02D933583BDF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {A1A0F8E8-FCB1-45A3-9397-02D933583BDF}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 EndGlobal

--- a/Program.cs
+++ b/Program.cs
@@ -28,7 +28,7 @@ if (args.Length != 1
 // Push to the nearest quarter.
 var startOfQuarterMonth = date.Month <= 3 ? 1 : date.Month <= 6 ? 4 : date.Month <= 9 ? 7 : 10;
 date = new DateOnly(date.Year, startOfQuarterMonth, 1);
-var quarter = $"{date:yyyy}-Q{(date.Month-1) / 3 + 1}";
+var quarter = CalculateQuarter(date);
 
 Console.WriteLine($"CreateSoundRoomSchedule for {quarter}");
 Console.WriteLine();

--- a/QuarterCalculator.cs
+++ b/QuarterCalculator.cs
@@ -1,0 +1,12 @@
+internal partial class Program
+{
+    internal static string CalculateQuarter(DateOnly date)
+    {
+        var startOfQuarterMonth = date.Month <= 3 ? 1
+            : date.Month <= 6 ? 4
+            : date.Month <= 9 ? 7
+            : 10;
+        date = new DateOnly(date.Year, startOfQuarterMonth, 1);
+        return $"{date:yyyy}-Q{(date.Month - 1) / 3 + 1}";
+    }
+}

--- a/tests/CreateSoundRoomSchedule.Tests/CreateSoundRoomSchedule.Tests.csproj
+++ b/tests/CreateSoundRoomSchedule.Tests/CreateSoundRoomSchedule.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CreateSoundRoomSchedule.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/CreateSoundRoomSchedule.Tests/QuarterTests.cs
+++ b/tests/CreateSoundRoomSchedule.Tests/QuarterTests.cs
@@ -1,0 +1,14 @@
+using Xunit;
+
+namespace CreateSoundRoomSchedule.Tests;
+
+public class QuarterTests
+{
+    [Fact]
+    public void CalculateQuarter_Returns_Q1_For_February_2025()
+    {
+        var date = new DateOnly(2025, 2, 1);
+        var quarter = Program.CalculateQuarter(date);
+        Assert.Equal("2025-Q1", quarter);
+    }
+}


### PR DESCRIPTION
## Summary
- add a partial Program class exposing `CalculateQuarter`
- add xUnit test project under `tests/`
- validate that quarter is calculated correctly for February 2025
- include test project in the solution

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a5e015ccc83309cba3dff9db50793