### PR TITLE
Exclude test files from main project

### DIFF
--- a/CreateSoundRoomSchedule.csproj
+++ b/CreateSoundRoomSchedule.csproj
@@ -8,10 +8,13 @@
         <UserSecretsId>264f11e8-c633-4cb1-a9ca-aab85e784b5f</UserSecretsId>
     </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="EPPlus" Version="7.5.2" />
-      <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="EPPlus" Version="7.5.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="tests/**/*.cs" />
+  </ItemGroup>
 
 </Project>

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("CreateSoundRoomSchedule.Tests")]

--- a/tests/CreateSoundRoomSchedule.Tests/CreateSoundRoomSchedule.Tests.csproj
+++ b/tests/CreateSoundRoomSchedule.Tests/CreateSoundRoomSchedule.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
@@ -14,6 +15,6 @@
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\CreateSoundRoomSchedule.csproj" />
+    <ProjectReference Include="..\..\CreateSoundRoomSchedule.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- exclude the `tests` folder from `CreateSoundRoomSchedule.csproj`
- enable implicit `System` usings for the xUnit project
- confirm tests pass

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687a64e4675c8330b3f7e1aa5bf4cd8f